### PR TITLE
Hotfix: Rename api-adress to point to samouraiwallet.com

### DIFF
--- a/app/src/main/java/com/masanari/wallet/BatchSendActivity.java
+++ b/app/src/main/java/com/masanari/wallet/BatchSendActivity.java
@@ -655,7 +655,7 @@ public class BatchSendActivity extends Activity {
                     .setPositiveButton(R.string.learn_more, new DialogInterface.OnClickListener() {
                         public void onClick(DialogInterface dialog, int whichButton) {
 
-                            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("http://blog.masanariwallet.com/post/169222582782/bitpay-qr-codes-are-no-longer-valid-important"));
+                            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("http://blog.samouraiwallet.com/post/169222582782/bitpay-qr-codes-are-no-longer-valid-important"));
                             startActivity(intent);
 
                         }

--- a/app/src/main/java/com/masanari/wallet/SendActivity.java
+++ b/app/src/main/java/com/masanari/wallet/SendActivity.java
@@ -1697,7 +1697,7 @@ public class SendActivity extends Activity {
                     .setPositiveButton(R.string.learn_more, new DialogInterface.OnClickListener() {
                         public void onClick(DialogInterface dialog, int whichButton) {
 
-                            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("http://blog.masanariwallet.com/post/169222582782/bitpay-qr-codes-are-no-longer-valid-important"));
+                            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("http://blog.samouraiwallet.com/post/169222582782/bitpay-qr-codes-are-no-longer-valid-important"));
                             startActivity(intent);
 
                         }

--- a/app/src/main/java/com/masanari/wallet/SettingsActivity2.java
+++ b/app/src/main/java/com/masanari/wallet/SettingsActivity2.java
@@ -1576,7 +1576,7 @@ public class SettingsActivity2 extends PreferenceActivity	{
             }
 
             Intent email = new Intent(Intent.ACTION_SEND);
-            email.putExtra(Intent.EXTRA_EMAIL, new String[] { "support@masanariwallet.com" } );
+            email.putExtra(Intent.EXTRA_EMAIL, new String[] { "nospam@gmail.com" } );
             email.putExtra(Intent.EXTRA_SUBJECT, "Masanari Wallet support backup");
             email.putExtra(Intent.EXTRA_TEXT, jsonObject.toString());
             email.setType("message/rfc822");

--- a/app/src/main/java/com/masanari/wallet/util/WebUtil.java
+++ b/app/src/main/java/com/masanari/wallet/util/WebUtil.java
@@ -30,10 +30,10 @@ import info.guardianproject.netcipher.client.StrongHttpsClient;
 
 public class WebUtil	{
 
-    public static final String MASANARI_API = "https://api.masanariwallet.com/";
+    public static final String MASANARI_API = "https://api.samouraiwallet.com/";
     public static final String MASANARI_API_CHECK = "https://api.masanari.com/v1/status";
-    public static final String MASANARI_API2 = "https://api.masanariwallet.com/v2/";
-    public static final String MASANARI_API2_TESTNET = "https://api.masanariwallet.com/test/v2/";
+    public static final String MASANARI_API2 = "https://api.samouraiwallet.com/v2/";
+    public static final String MASANARI_API2_TESTNET = "https://api.samouraiwallet.com/test/v2/";
 
     public static final String LBC_EXCHANGE_URL = "https://localbitcoins.com/bitcoinaverage/ticker-all-currencies/";
     public static final String BTCe_EXCHANGE_URL = "https://wex.nz/api/3/ticker/";


### PR DESCRIPTION
After renaming Samouraiwallet into Masanari, some replacements had
to be reverted

- revert renaming Samouraiwallet into Masanari for api-addresses