### PR TITLE
Fix crash when clicking openvpn market link from within the app

### DIFF
--- a/app/src/main/java/com/masanari/wallet/SettingsActivity2.java
+++ b/app/src/main/java/com/masanari/wallet/SettingsActivity2.java
@@ -772,7 +772,8 @@ public class SettingsActivity2 extends PreferenceActivity	{
                             startActivity(intent);
                         }
                         catch(PackageManager.NameNotFoundException nnfe)	{
-                            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=" + AppUtil.OPENVPN_PACKAGE_ID));
+                            Intent intent = new Intent(Intent.ACTION_VIEW);
+                            intent.setData(Uri.parse("https://play.google.com/store/apps/details?id=" + AppUtil.OPENVPN_PACKAGE_ID));
                             startActivity(intent);
                         }
 


### PR DESCRIPTION
When you click the marketlink to the openvpn app
and your phone can't handle market:// links, it crashes

- Change market link into https:// link